### PR TITLE
Revise SDL-0293 Enable OEM exclusive apps support - vol.2

### DIFF
--- a/proposals/0293-vehicle-type-filter.md
+++ b/proposals/0293-vehicle-type-filter.md
@@ -1,9 +1,9 @@
 # Enable OEM exclusive apps support
 
 * Proposal: [SDL-0293](0293-vehicle-type-filter.md)
-* Author: [Ashwin Karemore](https://github.com/ashwink11)
+* Author: [Ashwin Karemore](https://github.com/ashwink11) and [Iryna Lytvynenko](https://github.com/LitvinenkoIra)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / Protocol / JavaScript Suite]
+* Impacted Platforms: [Core / iOS / Java Suite / Protocol / JavaScript Suite / HMI / RPC]
 
 ## Introduction
 
@@ -66,6 +66,31 @@ The BSON payload of this message will have the following info.
 |trim|String| Vehicle trim |
 |systemSoftwareVersion|String| Vehicle system software version |
 |systemHardwareVersion|String| Vehicle system hardware version |
+
+### MOBILE_API Changes
+
+#### Addition of "RegisterAppInterface" function
+
+```xml
+<function name="RegisterAppInterface" functionID="RegisterAppInterfaceID" messagetype="response" since="1.0">
+    :
+    <param name="systemHardwareVersion" type="String" maxlength="500" mandatory="false" platform="documentation" since="X.X">
+        <description>The hardware version of the system</description>
+    </param>
+</function>
+```
+### HMI_API Changes
+
+#### Addition of "GetSystemInfo" function
+
+```xml
+<function name="GetSystemInfo" messagetype="response">
+    :
+    <param name="systemHardwareVersion" type="String" maxlength="500" mandatory="false">
+        <description>The hardware version of the system</description>
+    </param>
+</function>
+```
 
 ### iOS, JavaScript Suite, and Java Suite App Library Changes
 


### PR DESCRIPTION
Add `systemHardwareVersion` as a parameter to the `RegisterAppInterface` response in the Mobile API and to the `GetSystemInfo` response in the HMI API. 

The thing that confuses me - is that the [ccpu_version in the HMI API](https://github.com/LuxoftSDL/sdl_core/blob/develop/src/components/interfaces/HMI_API.xml#L4783) has the maxlength="500" 
But the [systemSoftwareVersion in the Mobile API](https://github.com/smartdevicelink/rpc_spec/blob/develop/MOBILE_API.xml#L4915) has the maxlength="100" 
I decided to use a longer length for the new `systemHardwareVersion` parameter

Please compare this approach with the one described here: https://github.com/LuxoftSDL/sdl_evolution/pull/4

Feel free to post all thoughts and suggestions related to this point and to the overall proposal.
